### PR TITLE
Support Unity 2017

### DIFF
--- a/src/MasterMemory/src/Internal/DictionaryView.cs
+++ b/src/MasterMemory/src/Internal/DictionaryView.cs
@@ -16,7 +16,7 @@ using System.Linq;
 namespace MasterMemory.Internal
 {
     public class DictionaryView<TKey, TElement> : IDictionary<TKey, TElement>
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
     , IReadOnlyDictionary<TKey, TElement>
 #endif
     {
@@ -89,7 +89,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TElement>.Keys
         {
@@ -159,7 +159,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView1<TKey1, TKey2, TElement> : IDictionary<TKey1, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<TKey1, TElement>
 #endif
     {
@@ -232,7 +232,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<TKey1> IReadOnlyDictionary<TKey1, TElement>.Keys
         {
@@ -301,7 +301,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView1<TKey1, TKey2, TKey3, TElement> : IDictionary<TKey1, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<TKey1, TElement>
 #endif
     {
@@ -374,7 +374,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<TKey1> IReadOnlyDictionary<TKey1, TElement>.Keys
         {
@@ -442,7 +442,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView12<TKey1, TKey2, TKey3, TElement> : IDictionary<MemoryKey<TKey1, TKey2>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>
 #endif
     {
@@ -515,7 +515,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>.Keys
         {
@@ -584,7 +584,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView1<TKey1, TKey2, TKey3, TKey4, TElement> : IDictionary<TKey1, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<TKey1, TElement>
 #endif
     {
@@ -657,7 +657,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<TKey1> IReadOnlyDictionary<TKey1, TElement>.Keys
         {
@@ -725,7 +725,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView12<TKey1, TKey2, TKey3, TKey4, TElement> : IDictionary<MemoryKey<TKey1, TKey2>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>
 #endif
     {
@@ -798,7 +798,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>.Keys
         {
@@ -866,7 +866,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView123<TKey1, TKey2, TKey3, TKey4, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>
 #endif
     {
@@ -939,7 +939,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>.Keys
         {
@@ -1008,7 +1008,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView1<TKey1, TKey2, TKey3, TKey4, TKey5, TElement> : IDictionary<TKey1, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<TKey1, TElement>
 #endif
     {
@@ -1081,7 +1081,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<TKey1> IReadOnlyDictionary<TKey1, TElement>.Keys
         {
@@ -1149,7 +1149,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView12<TKey1, TKey2, TKey3, TKey4, TKey5, TElement> : IDictionary<MemoryKey<TKey1, TKey2>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>
 #endif
     {
@@ -1222,7 +1222,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>.Keys
         {
@@ -1290,7 +1290,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView123<TKey1, TKey2, TKey3, TKey4, TKey5, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>
 #endif
     {
@@ -1363,7 +1363,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>.Keys
         {
@@ -1431,7 +1431,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView1234<TKey1, TKey2, TKey3, TKey4, TKey5, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement>
 #endif
     {
@@ -1504,7 +1504,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3, TKey4>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement>.Keys
         {
@@ -1573,7 +1573,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView1<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement> : IDictionary<TKey1, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<TKey1, TElement>
 #endif
     {
@@ -1646,7 +1646,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<TKey1> IReadOnlyDictionary<TKey1, TElement>.Keys
         {
@@ -1714,7 +1714,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView12<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement> : IDictionary<MemoryKey<TKey1, TKey2>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>
 #endif
     {
@@ -1787,7 +1787,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>.Keys
         {
@@ -1855,7 +1855,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView123<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>
 #endif
     {
@@ -1928,7 +1928,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>.Keys
         {
@@ -1996,7 +1996,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView1234<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement>
 #endif
     {
@@ -2069,7 +2069,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3, TKey4>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement>.Keys
         {
@@ -2137,7 +2137,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView12345<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement>
 #endif
     {
@@ -2210,7 +2210,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement>.Keys
         {
@@ -2279,7 +2279,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView1<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement> : IDictionary<TKey1, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<TKey1, TElement>
 #endif
     {
@@ -2352,7 +2352,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<TKey1> IReadOnlyDictionary<TKey1, TElement>.Keys
         {
@@ -2420,7 +2420,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView12<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement> : IDictionary<MemoryKey<TKey1, TKey2>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>
 #endif
     {
@@ -2493,7 +2493,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement>.Keys
         {
@@ -2561,7 +2561,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView123<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>
 #endif
     {
@@ -2634,7 +2634,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement>.Keys
         {
@@ -2702,7 +2702,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView1234<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement>
 #endif
     {
@@ -2775,7 +2775,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3, TKey4>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement>.Keys
         {
@@ -2843,7 +2843,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView12345<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement>
 #endif
     {
@@ -2916,7 +2916,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement>.Keys
         {
@@ -2984,7 +2984,7 @@ namespace MasterMemory.Internal
 
 
     public class DictionaryView123456<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement> : IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6>, TElement>   
-#if !UNITY_5    
+#if !UNITY_5_3_OR_NEWER    
     , IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6>, TElement>
 #endif
     {
@@ -3057,7 +3057,7 @@ namespace MasterMemory.Internal
                 throw new NotSupportedException();
             }
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
 
         IEnumerable<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6>> IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6>, TElement>.Keys
         {

--- a/src/MasterMemory/src/Internal/MemoryKeyMemory.cs
+++ b/src/MasterMemory/src/Internal/MemoryKeyMemory.cs
@@ -59,7 +59,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView1<TKey1, TKey2, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<TKey1, TElement> ToDictionaryView()
 #else
         public IDictionary<TKey1, TElement> ToDictionaryView()
@@ -127,7 +127,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView1<TKey1, TKey2, TKey3, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<TKey1, TElement> ToDictionaryView()
 #else
         public IDictionary<TKey1, TElement> ToDictionaryView()
@@ -195,7 +195,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView12<TKey1, TKey2, TKey3, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
@@ -263,7 +263,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView1<TKey1, TKey2, TKey3, TKey4, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<TKey1, TElement> ToDictionaryView()
 #else
         public IDictionary<TKey1, TElement> ToDictionaryView()
@@ -331,7 +331,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView12<TKey1, TKey2, TKey3, TKey4, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
@@ -399,7 +399,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView123<TKey1, TKey2, TKey3, TKey4, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement> ToDictionaryView()
@@ -467,7 +467,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView1<TKey1, TKey2, TKey3, TKey4, TKey5, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<TKey1, TElement> ToDictionaryView()
 #else
         public IDictionary<TKey1, TElement> ToDictionaryView()
@@ -535,7 +535,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView12<TKey1, TKey2, TKey3, TKey4, TKey5, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
@@ -603,7 +603,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView123<TKey1, TKey2, TKey3, TKey4, TKey5, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement> ToDictionaryView()
@@ -671,7 +671,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView1234<TKey1, TKey2, TKey3, TKey4, TKey5, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement> ToDictionaryView()
@@ -739,7 +739,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView1<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<TKey1, TElement> ToDictionaryView()
 #else
         public IDictionary<TKey1, TElement> ToDictionaryView()
@@ -807,7 +807,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView12<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
@@ -875,7 +875,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView123<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement> ToDictionaryView()
@@ -943,7 +943,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView1234<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement> ToDictionaryView()
@@ -1011,7 +1011,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView12345<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement> ToDictionaryView()
@@ -1079,7 +1079,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView1<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<TKey1, TElement> ToDictionaryView()
 #else
         public IDictionary<TKey1, TElement> ToDictionaryView()
@@ -1147,7 +1147,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView12<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2>, TElement> ToDictionaryView()
@@ -1215,7 +1215,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView123<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3>, TElement> ToDictionaryView()
@@ -1283,7 +1283,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView1234<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4>, TElement> ToDictionaryView()
@@ -1351,7 +1351,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView12345<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5>, TElement> ToDictionaryView()
@@ -1419,7 +1419,7 @@ namespace MasterMemory.Internal
         {
             return new LookupView123456<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6, TKey7, TElement>(this);
         }
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         public IReadOnlyDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6>, TElement> ToDictionaryView()
 #else
         public IDictionary<MemoryKey<TKey1, TKey2, TKey3, TKey4, TKey5, TKey6>, TElement> ToDictionaryView()

--- a/src/MasterMemory/src/Memory.cs
+++ b/src/MasterMemory/src/Memory.cs
@@ -43,7 +43,7 @@ namespace MasterMemory
         RangeView<TElement> FindAll(bool ascendant = true);
 
         ILookup<TKey, TElement> ToLookupView();
-#if UNITY_5
+#if UNITY_5_3_OR_NEWER
         IDictionary<TKey, TElement> ToDictionaryView();
 #else
         IReadOnlyDictionary<TKey, TElement> ToDictionaryView();
@@ -303,7 +303,7 @@ namespace MasterMemory
             return new LookupView<TKey, TElement>(this);
         }
 
-#if UNITY_5
+#if UNITY_5_3_OR_NEWER
         public IDictionary<TKey, TElement> ToDictionaryView()
 #else
         public IReadOnlyDictionary<TKey, TElement> ToDictionaryView()

--- a/src/MasterMemory/src/RangeView.cs
+++ b/src/MasterMemory/src/RangeView.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace MasterMemory
 {
     public struct RangeView<T> : IEnumerable<T>, IList<T>
-#if !UNITY_5
+#if !UNITY_5_3_OR_NEWER
         , IReadOnlyList<T>
 #endif
     {


### PR DESCRIPTION
When attempting to run the MasterMemory package in Unity 2017.1.0p4, the following error is thrown:

"Assets/src/Internal/DictionaryView(): error CS0246: The type or namespace name 'IReadOnlyDictionary' could not be found. Are you missing an assembly reference?"

This is being thrown because the Unity Platform Define directives are set to `#if !Unity5`, which does not account for later versions such as Unity 2017.

This pull request is to update these directives to `#if !Unity_5_3_OR_NEWER` which accounts for all versions later than Unity 5.3.4.