### PR TITLE
fix Roslyn MSBuildWorkspace Type duplication error by Microsoft.Build…

### DIFF
--- a/src/MasterMemory.CodeGenerator/MasterMemory.CodeGenerator.csproj
+++ b/src/MasterMemory.CodeGenerator/MasterMemory.CodeGenerator.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.Build.Locator.1.0.18\build\Microsoft.Build.Locator.props" Condition="Exists('..\..\packages\Microsoft.Build.Locator.1.0.18\build\Microsoft.Build.Locator.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,6 +36,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build.Locator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Build.Locator.1.0.18\lib\net46\Microsoft.Build.Locator.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
@@ -184,6 +190,14 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Build.Locator.1.0.18\build\Microsoft.Build.Locator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Build.Locator.1.0.18\build\Microsoft.Build.Locator.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Build.Locator.1.0.18\build\Microsoft.Build.Locator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Build.Locator.1.0.18\build\Microsoft.Build.Locator.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.Build.Locator.1.0.18\build\Microsoft.Build.Locator.targets" Condition="Exists('..\..\packages\Microsoft.Build.Locator.1.0.18\build\Microsoft.Build.Locator.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/MasterMemory.CodeGenerator/Program.cs
+++ b/src/MasterMemory.CodeGenerator/Program.cs
@@ -65,6 +65,8 @@ namespace MasterMemory.CodeGenerator
     {
         static void Main(string[] args)
         {
+            Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults();
+
             var cmdArgs = new CommandlineArguments(args);
             if (!cmdArgs.IsParsed)
             {

--- a/src/MasterMemory.CodeGenerator/Utils/RoslynExtensions.cs
+++ b/src/MasterMemory.CodeGenerator/Utils/RoslynExtensions.cs
@@ -54,12 +54,20 @@ namespace MasterMemory.CodeGenerator
             }
 
             var workspace = MSBuildWorkspace.Create();
+            workspace.WorkspaceFailed += Workspace_WorkspaceFailed;
+
             var project = await workspace.OpenProjectAsync(csprojPath).ConfigureAwait(false);
             project = project.AddMetadataReferences(externalReferences); // workaround:)
             project = project.WithParseOptions((project.ParseOptions as CSharpParseOptions).WithPreprocessorSymbols(preprocessorSymbols));
 
             var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
             return compilation;
+        }
+
+        private static void Workspace_WorkspaceFailed(object sender, WorkspaceDiagnosticEventArgs e)
+        {
+            Console.WriteLine(e.Diagnostic.ToString());
+            // throw new Exception(e.Diagnostic.ToString());
         }
 
         public static IEnumerable<INamedTypeSymbol> GetNamedTypeSymbols(this Compilation compilation)

--- a/src/MasterMemory.CodeGenerator/packages.config
+++ b/src/MasterMemory.CodeGenerator/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Build.Locator" version="1.0.18" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net461" />


### PR DESCRIPTION
- fix Roslyn MSBuildWorkspace Type duplication error by Microsoft.Build.Locator
- add error message when WorkspaceFailed event (same code as MessagePack Coder Generator)

RoslynのMSBuild用WorkspaceがVS内のMSBuildと衝突してエラーになるようなので、
Microsoft.Build.Locatorを使用して使用されるMSBuildを統一しています。
あと、WorkspaceFailedに関しては無言で失敗していたのでエラー出力をmpc.exe同等にしました。

